### PR TITLE
Fix Dependencies

### DIFF
--- a/elibs/CMakeLists.txt
+++ b/elibs/CMakeLists.txt
@@ -12,7 +12,7 @@ externalproject_add(ext_mapmap
 externalproject_add(ext_rayint
     PREFIX          ext_rayint
     GIT_REPOSITORY  https://github.com/nmoehrle/rayint.git
-    GIT_TAG         cuda
+    GIT_TAG         d5a8126aebb98c68b2b98bea05fcc8cebb6a2fb9
     UPDATE_COMMAND  ""
     SOURCE_DIR      ${CMAKE_SOURCE_DIR}/elibs/rayint
     CONFIGURE_COMMAND ""

--- a/elibs/CMakeLists.txt
+++ b/elibs/CMakeLists.txt
@@ -1,7 +1,7 @@
 externalproject_add(ext_mapmap
     PREFIX          ext_mapmap
     GIT_REPOSITORY  https://github.com/dthuerck/mapmap_cpu.git
-    GIT_TAG         master
+    GIT_TAG         55cd9374f6467263f2741474a5e78e68417d7465
     UPDATE_COMMAND  ""
     SOURCE_DIR      ${CMAKE_SOURCE_DIR}/elibs/mapmap
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
Turns out that these subdeps weren't version locked. An upstream update caused the `dset.h` breakage that dk was running into.