### PR TITLE
Add option to end before creating texture atlas

### DIFF
--- a/elibs/CMakeLists.txt
+++ b/elibs/CMakeLists.txt
@@ -1,7 +1,7 @@
 externalproject_add(ext_mapmap
     PREFIX          ext_mapmap
     GIT_REPOSITORY  https://github.com/dthuerck/mapmap_cpu.git
-    GIT_TAG         master
+    GIT_TAG         55cd9374f6467263f2741474a5e78e68417d7465
     UPDATE_COMMAND  ""
     SOURCE_DIR      ${CMAKE_SOURCE_DIR}/elibs/mapmap
     CONFIGURE_COMMAND ""
@@ -12,7 +12,7 @@ externalproject_add(ext_mapmap
 externalproject_add(ext_rayint
     PREFIX          ext_rayint
     GIT_REPOSITORY  https://github.com/nmoehrle/rayint.git
-    GIT_TAG         cuda
+    GIT_TAG         d5a8126aebb98c68b2b98bea05fcc8cebb6a2fb9
     UPDATE_COMMAND  ""
     SOURCE_DIR      ${CMAKE_SOURCE_DIR}/elibs/rayint
     CONFIGURE_COMMAND ""

--- a/libs/mvs_tex_wrapper/wrapper.h
+++ b/libs/mvs_tex_wrapper/wrapper.h
@@ -35,5 +35,7 @@ void textureMesh(const TextureSettings& texture_settings,
                  std::shared_ptr<EuclideanViewMask> ev_mask = NULL,
                  uint atlas_size = 0,
                  float* hidden_face_proportion = NULL,
-                 std::vector<std::vector<uint8_t>> *segmentation_classes = nullptr);
+                 std::vector<std::vector<uint8_t>> *segmentation_classes = nullptr,
+                 bool do_texture_atlas = true); // if segmentation classes are to be set (i.e. not a nullptr), then setting this to false stops method after setting segmentation classes to avoid wasting time if textures are not needed.
+// setting to false only has an effect if image has more channels than colors--otherwise defaults to doing the atlas every time
 }  // namespace MvsTexturing


### PR DESCRIPTION
This is a performance enhancement because creating the point-cloud segmentation data doesn't require also doing the texture mesh.  So in the pipeline call, we can just create the point cloud.