### PR TITLE
Texture atlas pink pixels

### DIFF
--- a/libs/mvs_tex_wrapper/wrapper.cpp
+++ b/libs/mvs_tex_wrapper/wrapper.cpp
@@ -302,7 +302,7 @@ void textureMesh(
       auto texture_patch = texture_patches[i];
       
       //  FIXME - bitweeder
-      //  This is unused if we only care about generating masks.
+      //  This is a wasted allocation if we only care about generating masks.
       vector<math::Vec3f> patch_adjust_values(
           texture_patch->get_faces().size() * 3, math::Vec3f(0.0f));
 

--- a/libs/mvs_tex_wrapper/wrapper.cpp
+++ b/libs/mvs_tex_wrapper/wrapper.cpp
@@ -312,7 +312,7 @@ void textureMesh(
         //  masks generated for local seam leveling.
         texture_patch->adjust_colors(patch_adjust_values, true);
       } else {
-         texture_patch->adjust_colors(patch_adjust_values);
+        texture_patch->adjust_colors(patch_adjust_values);
       }
       
       texture_patch_counter.inc();

--- a/libs/mvs_tex_wrapper/wrapper.cpp
+++ b/libs/mvs_tex_wrapper/wrapper.cpp
@@ -278,9 +278,10 @@ void textureMesh(
   if (settings.global_seam_leveling) {
     //  FIXME - bitweeder
     //  Making global seam leveling work with scaling will probably require
-    //  not calling adjust_colors from within global_seam_leveling when
-    //  scaling, instead relying on the post-scaling call. regenerate_masks()
-    //  should still be called, though. This theory is untested.
+    //  calling adjust_colors from within global_seam_leveling with
+    //  only_regenerate_masks set to true when scaling, then relying on the
+    //  post-scaling call to adjust_colors to do the actual adjustment.
+    //  This theory is untested.
     
     // TODO dwh: can we get here if doing segmentation??
     std::cout << "Running global seam leveling:" << std::endl;
@@ -300,16 +301,18 @@ void textureMesh(
 
       auto texture_patch = texture_patches[i];
       
-      if (settings.scale_if_needed) {
+      //  FIXME - bitweeder
+      //  This is unused if we only care about generating masks.
+      vector<math::Vec3f> patch_adjust_values(
+          texture_patch->get_faces().size() * 3, math::Vec3f(0.0f));
+
+     if (settings.scale_if_needed) {
         //  We’ll be running adjust_colors after scaling, in this case; running
         //  it twice would lead to artifacts. We do, however, still need the
         //  masks generated for local seam leveling.
-        texture_patch->regenerate_masks();
+        texture_patch->adjust_colors(patch_adjust_values, true);
       } else {
-        vector<math::Vec3f> patch_adjust_values(
-            texture_patch->get_faces().size() * 3, math::Vec3f(0.0f));
-
-        texture_patch->adjust_colors(patch_adjust_values);
+         texture_patch->adjust_colors(patch_adjust_values);
       }
       
       texture_patch_counter.inc();

--- a/libs/tex/generate_texture_atlases.cpp
+++ b/libs/tex/generate_texture_atlases.cpp
@@ -179,6 +179,10 @@ TexturePatches prepare_patches(
   return nrv;
 }
 
+/**
+  @brief Generate a scaled texture atlas guaranteed to fit within a single page
+  sized to the supplied bounds.
+*/
 void generate_capped_texture_atlas(
     TexturePatches* orig_texture_patches,
     Settings const& settings,
@@ -205,7 +209,12 @@ void generate_capped_texture_atlas(
   //  a useful value. Note that it is not feasible to be precise, as
   //  complications ensue depending on the relative number of small charts,
   //  the size of the chart borders, the packing algorithm being used, and
-  //  possibly the shape of the charts.
+  //  possibly the shape of the charts, but mostly because the atlas generation
+  //  algorithm is non-deterministic and we don’t cache our intermediate
+  //  stages. A -lot- less work could be done here with sigificant refactoring
+  //  such that only the AABB bounds for each chart are generated for the
+  //  purpose of packing, and then we do the final image transfers/scaling once
+  //  we’ve settled on a layout.
   double scaling = 1.0;
   std::size_t iterations = 0;
 
@@ -259,7 +268,6 @@ void generate_capped_texture_atlas(
         //  Generate a deep copy of the original patch.
         auto patch = TexturePatch::create(texture_patches[i]);
 
-//        patch->rescale_manually(scaling);
         patch->rescale(scaling);
 
         auto& tc = patch->get_texcoords();

--- a/libs/tex/generate_texture_patches.cpp
+++ b/libs/tex/generate_texture_patches.cpp
@@ -134,7 +134,7 @@ TexturePatchCandidate generate_candidate(
 
   mve::ByteImage::Ptr byte_image = mve::image::crop(
       view_image, width, height, min_x, min_y, *math::Vec3uc(255, 0, 255));
-
+  
   mve::FloatImage::Ptr image = mve::image::byte_to_float_image(byte_image);
 
   //  TESTME - bitweeder

--- a/libs/tex/texture_atlas.h
+++ b/libs/tex/texture_atlas.h
@@ -97,10 +97,10 @@ inline uint compute_local_padding(
   uint size = std::max(base_width, base_height);
   uint local_padding = std::min(std::max(2u, size >> 4), max_padding);
 
-  //  FIXME - bitweeder
-  //  This is a test; it seems excessive to have a border wider than 2 pixels,
-  //  even with anisotropic/trilinear filtering. Testing a smaller value to
-  //  conserve space.
+  //  SEEME - bitweeder
+  //  It’s excessive to have a border wider than 2 pixels, even with
+  //  anisotropic/trilinear filtering. The original logic has been preserved,
+  //  but theresult is now hard-coded.
   return 2;
 //  return local_padding;
 }

--- a/libs/tex/texture_patch.cpp
+++ b/libs/tex/texture_patch.cpp
@@ -433,7 +433,10 @@ void TexturePatch::rescale(double ratio) {
   validity_mask = mve::ByteImage::create(get_width(), get_height(), 1);
   blending_mask = mve::ByteImage::create(get_width(), get_height(), 1);
 
-  //  Strictly speaking, these calls end up being redundant.
+  //  FIXME - bitweeder
+  //  Strictly speaking, these calls end up being redundant. Most likely, they
+  //  should remain here and the other places we set them should have
+  //  zero-fill as a precondition.
   validity_mask->fill(0);
   blending_mask->fill(0);
 
@@ -627,6 +630,7 @@ void TexturePatch::regenerate_masks() {
   assert(!!validity_mask);
 
   validity_mask->fill(0);
+  blending_mask->fill(0);
 
   if (texcoords.size() < 3) {
     return;

--- a/libs/tex/texture_patch.cpp
+++ b/libs/tex/texture_patch.cpp
@@ -129,8 +129,12 @@ TexturePatch::TexturePatch(
 }
 
 /**
-  @details This coordinate generator mirrors the logic used to scale the
-  patches.
+  @brief Transform the supplied texture coordinate.
+ 
+  @details The coordinate transformation mirrors the one used for image scaling
+  in rescale_area. In particular, it assumes that both the old and new images
+  being pointed into have unused texture_patch_border-pixel-wide borders outset
+  from the actual image data.
 */
 math::Vec2f scale_texcoord(
     math::Vec2f const& tc,
@@ -140,77 +144,24 @@ math::Vec2f scale_texcoord(
     int new_height);
 math::Vec2f scale_texcoord(
     math::Vec2f const& tc,
-    int old_width,
-    int old_height,
-    int new_width,
-    int new_height) {
-  math::Vec2f nrv {};
+    int old_width_i,
+    int old_height_i,
+    int new_width_i,
+    int new_height_i) {
+  math::Vec2f nrv {0.0f};
   
-  const float w0 = static_cast<float>(old_width);
-  const float w1 = static_cast<float>(new_width - 2.0f * texture_patch_border);
-  const float h0 = static_cast<float>(old_height);
-  const float h1 = static_cast<float>(new_height - 2.0f * texture_patch_border);
+  const auto offset = static_cast<float>(texture_patch_border);
+  const auto w0_a = old_width_i - 2 * offset;
+  const auto h0_a = old_height_i - 2 * offset;
+  const auto w1_a = new_width_i - 2 * offset;
+  const auto h1_a = new_height_i - 2 * offset;
+  const auto x_scale = static_cast<float>(w1_a) / static_cast<float>(w0_a);
+  const auto y_scale = static_cast<float>(h1_a) / static_cast<float>(h0_a);
 
-  float x = tc[0] * (w1 / w0) + texture_patch_border;
-  float y = tc[1] * (h1 / h0) + texture_patch_border;
-  float x_prop = std::min(1.0f, (std::floor(x) + 1 - x) * (w0 / w1));
-  float y_prop = std::min(1.0f, (std::floor(y) + 1 - y) * (h0 / h1));
+  auto x = (tc[0] - offset) * x_scale + offset;
+  auto y = (tc[1] - offset) * y_scale + offset;
 
-   #define HM_ASSERT(test_) \
-      if (!(test_)) {\
-        std::cout << "failed: " << #test_ << std::endl; \
-        std::cout \
-        << "texcoords: (" \
-        << tc[0] << ", " \
-        << tc[1] << "), " \
-        << "old: (" \
-        << w0 << ", " \
-        << h0 << "), " \
-        << "new: (" \
-        << w1 << ", " \
-        << h1 << "), " \
-        << "nrv: (" \
-        << nrv[0] << ", " \
-        << nrv[1] << "), " \
-        << "(x, y): (" \
-        << x << ", " \
-        << y << "), " \
-        << "prop: (" \
-        << x_prop << ", " \
-        << y_prop << ")\n" \
-        << std::endl; \
-        assert(test_); \
-      }
-
-  HM_ASSERT(tc[0] >= 0.0f);
-  HM_ASSERT(tc[0] < old_width);
-  HM_ASSERT(tc[1] >= 0.0f);
-  HM_ASSERT(tc[1] <= old_height);
-
-  //  FIXME - bitweeder
-  //  Placeholder logic. We may need to determine the extrema of the
-  //  rect that circumscribes the triangle and assign the appropriate coords
-  //  based on where the input coords fall relative to those. Arguably, the
-  //  current approach should be fine because we apply it consistently, but I
-  //  suspect it presents a problem on chart boundaries since the charts may
-  //  be rotated with respect to each other, rendering this simple tex coord
-  //  approach useless.
-  if (x_prop > 0.999 && y_prop > 0.999) {
-    nrv = {x, y};
-  } else if (x_prop > 0.999) {
-    nrv = {x, y + texture_patch_border};
-  } else if (y_prop > 0.999) {
-    nrv = {x + texture_patch_border, y};
-  } else {
-    nrv = {x + texture_patch_border, y + texture_patch_border};
-  }
-
-  HM_ASSERT(nrv[0] >= texture_patch_border);
-  HM_ASSERT(nrv[0] <= new_width - texture_patch_border);
-  HM_ASSERT(nrv[1] >= texture_patch_border);
-  HM_ASSERT(nrv[1] <= new_height - texture_patch_border);
-
-  #undef HM_ASSERT
+  nrv = {x, y};
 
   return nrv;
 }
@@ -222,183 +173,147 @@ math::Vec2f scale_texcoord(
   the conversion from the original coordinates. Note that this algorithm is
   content-agnostic; every texel in the rescale area will be processed
   regardless of whether it contains any signal.
- 
-  SEEME - bitweeder
-  This will play merry hell with texture coordinates, especially in an atlas,
-  and especially if the neighboring charts are scaled at different rates or
-  rotated relative to the adjacent adges. A more transformation-agnostic
-  variant would use a 3x3 grid centered on the original texel.
 */
 mve::FloatImage::Ptr rescale_area(
-    mve::FloatImage::Ptr input_image,
-    const int new_width,
-    const int new_height);
+    mve::FloatImage::Ptr image_i,
+    const int new_width_i,
+    const int new_height_i);
 mve::FloatImage::Ptr rescale_area(
-    mve::FloatImage::Ptr input_image,
-    const int new_width,
-    const int new_height) {
-  assert(!!input_image);
-  assert(new_width <= input_image->width());
-  assert(new_height <= input_image->height());
+    mve::FloatImage::Ptr image_i,
+    const int new_width_i,
+    const int new_height_i) {
+  assert(!!image_i);
   
+  //  Note that mve-cropped images incorporate a border. We need to maintain
+  //  that border at the precise width it started at, even after scaling. To
+  //  accommodate this, we subtract out the border and then add it back in
+  //  after scaling.
+  const auto offset = texture_patch_border;
+  const auto w0 = image_i->width();
+  const auto h0 = image_i->height();
+  const auto w0_a = image_i->width() - 2 * offset;
+  const auto h0_a = image_i->height() - 2 * offset;
+  const auto w1 = new_width_i;
+  const auto h1 = new_height_i;
+  const auto w1_a = new_width_i - 2 * offset;
+  const auto h1_a = new_height_i - 2 * offset;
+  const auto x_scale = static_cast<float>(w1_a) / static_cast<float>(w0_a);
+  const auto y_scale = static_cast<float>(h1_a) / static_cast<float>(h0_a);
+  const auto scale = x_scale * y_scale;
+
   auto out_image(mve::FloatImage::create());
 
-  out_image->allocate(new_width, new_height, input_image->channels());
-  out_image->fill(0.0);
+  out_image->allocate(w1, h1, image_i->channels());
+  out_image->fill(0.0f);
 
-  /*
-    We outset the original extents to create a simulated border around the
-    source image. This is done in order to improve the texel color result for
-    border pixels in the chart when applying linear filtering, as otherwise
-    they may end up too faint, in this case tending towards black. We account
-    for the adjustment below.
+  //  Track where we are in the fractional pixel.
+  auto calc_prop = [](auto low, auto scale){
+    return std::min(1.0f, (std::floor(low) + 1.0f - low) / scale);
+  };
   
-//    Additionally, we inset the extents of the new rect so that there will be a
-//    reserved border around the interior of the chart. This is to accommodate
-//    the triangle masks, which assume they occupy a one-pixel border around a
-//    given triangle.
+  auto test_prop = [](auto prop){
+    const float k_prop_threshold =  0.999f;
+    return prop > k_prop_threshold;
+  };
   
-    FIXME - bitweeder
-    Note that the approach taken here is naive and branch-heavy. A better
-    solution would incorporate tests transparently. This way is easy to
-    reason about and test, and also benefits from expedience.
-  */
-  const auto old_width = input_image->width();
-  const auto old_height = input_image->height();
-  const auto v_old_width = input_image->width() + 2 * texture_patch_border;
-  const auto v_old_height = input_image->height() + 2 * texture_patch_border;
-  const auto v_new_width = new_width;// - 2 * texture_patch_border;
-  const auto v_new_height = new_height;// - 2 * texture_patch_border;
-  const float x_scale = v_new_width / static_cast<float>(v_old_width);
-  const float y_scale = v_new_height / static_cast<float>(v_old_height);
-  const float scale = x_scale * y_scale;
+  //  Test against a half-open range of [min, max>
+  auto test_range = [](auto test_x, auto test_y,
+       auto min_x, auto min_y, auto max_x, auto max_y){
+      return (min_x <= test_x) && (min_y <= test_y)
+          && (test_x < max_x) && (test_y < max_y);
+  };
 
-  for (int ci = 0; ci < input_image->channels(); ++ci) {
-    for (int y = 0; y < v_old_height; ++y) {
-      //  Keep track of where our actual y is.
-      float y_low = static_cast<float>(y) * y_scale;// + texture_patch_border;
-      int new_y = static_cast<int>(std::floor(y_low));
+  for (int yi = 0; yi < h0; ++yi) {
+    auto src_y = (yi < offset) ? offset
+      : ((h0 - offset - 1 < yi) ? (h0 - offset - 1)
+      : yi);
 
-      //  Track where we are in the fractional pixel.
-      float y_prop = std::min(1.0f, (std::floor(y_low) + 1.0f - y_low) / y_scale);
+    auto dst_y_calc = static_cast<float>(src_y - offset) * y_scale + offset;
 
-      for (int x = 0; x < v_old_width; ++x) {
-        //  Keep track of where our actual x is.
-        float x_low = static_cast<float>(x) * x_scale;// + texture_patch_border;
-        int new_x = static_cast<int>(std::floor(x_low));
+    auto dst_y = (yi < offset) ? yi
+      : ((h0_a + offset <= yi) ? (yi + h1_a - h0_a)
+      : static_cast<int>(std::floor(dst_y_calc)));
 
-        //  Track where we are in the fractional pixel.
-        float x_prop = std::min(1.0f, (std::floor(x_low) + 1.0f - x_low) / x_scale);
+    auto y_prop = calc_prop(dst_y_calc, y_scale);
+    auto y_pure = test_prop(y_prop);
 
-        float val = 0.0f;
+    for (int xi = 0; xi < w0; ++xi) {
+      auto src_x = (xi < offset) ? offset
+        : ((w0 - offset - 1 < xi) ? (w0 - offset - 1)
+        : xi);
+
+      auto dst_x_calc = static_cast<float>(src_x - offset) * x_scale + offset;
+
+      auto dst_x = (xi < offset) ? xi
+        : ((w0_a + offset <= xi) ? (xi + w1_a - w0_a)
+        : static_cast<int>(std::floor(dst_x_calc)));
+
+      auto x_prop = calc_prop(dst_x_calc, x_scale);
+      auto x_pure = test_prop(x_prop);
+
+      for (int ci = 0; ci < image_i->channels(); ++ci) {
+        auto val = image_i->at(src_x, src_y, ci) * scale;
         
-        #define HM_ASSERT(test_) \
-          if (!(test_)) {\
-            std::cout << "failed: " << #test_ << std::endl; \
-            std::cout \
-              << "image dims: (" \
-              << input_image->width() << ", " \
-              << input_image->height() << "), " \
-              << "new: (" \
-              << new_width << ", " \
-              << new_height << "), " \
-              << "scale: (" \
-              << x_scale << ", " \
-              << y_scale << ")" \
-              << "image coords: (" \
-              << x << ", " << y << "), " \
-              << "prop: (" \
-              << x_prop << ", " << y_prop << "), " \
-              << "val: " << val \
-              << "max: (" << max_x << ", " << max_y << ")\n" \
-              << std::endl; \
-              assert(test_); \
+        //  Peform 2x2 linear filtering, avoiding out-of-bounds writes.
+        if (x_pure && y_pure) {
+          if (test_range (dst_x, dst_y, 0, 0, w1, h1)) {
+            out_image->at(dst_x, dst_y, ci) += val;
+          }
+        } else if (x_pure) {
+          if (test_range (dst_x, dst_y, 0, 0, w1, h1)) {
+            out_image->at(dst_x, dst_y, ci) += val * y_prop;
           }
 
-        //  This series of tests is intended to weed out our fake borders while
-        //  still behaving as if they actually existed. The net impact is to
-        //  ensure that border pixel colors are still properly normalized
-        //  instead of being fragments.
-        if (x < texture_patch_border) {
-          if (y < texture_patch_border) {
-            val = input_image->at(0, 0, ci) * scale;
-          } else if (y >= v_old_height - texture_patch_border) {
-            val = input_image->at(0, v_old_height - (2 * texture_patch_border + 1), ci) * scale;
-          } else {
-            val = input_image->at(0, y - texture_patch_border, ci) * scale;
+          if (test_range (dst_x, dst_y + 1, 0, 0, w1, h1)) {
+            out_image->at(dst_x, dst_y + 1, ci) += val * (1 - y_prop);
           }
-        } else if (x >= v_old_width - texture_patch_border) {
-          if (y < texture_patch_border) {
-            val = input_image->at(v_old_width - (2 * texture_patch_border + 1), 0, ci) * scale;
-          } else if (y >= v_old_height - texture_patch_border) {
-            val = input_image->at(v_old_width - (2 * texture_patch_border + 1), v_old_height - (2 * texture_patch_border + 1), ci) * scale;
-          } else {
-            val = input_image->at(v_old_width - (2 * texture_patch_border + 1), y - texture_patch_border, ci) * scale;
+        } else if (y_pure) {
+          if (test_range (dst_x, dst_y, 0, 0, w1, h1)) {
+            out_image->at(dst_x, dst_y, ci) += val * x_prop;
+          }
+
+          if (test_range (dst_x + 1, dst_y, 0, 0, w1, h1)) {
+            out_image->at(dst_x + 1, dst_y, ci) += val * (1 - x_prop);
           }
         } else {
-          if (y < texture_patch_border) {
-            val = input_image->at(x - texture_patch_border, 0, ci) * scale;
-          } else if (y >= v_old_height - texture_patch_border) {
-            val = input_image->at(x - texture_patch_border, v_old_height - (2 * texture_patch_border + 1), ci) * scale;
-          } else {
-            val = input_image->at(x - texture_patch_border, y - texture_patch_border, ci) * scale;
+          if (test_range (dst_x, dst_y, 0, 0, w1, h1)) {
+            out_image->at(dst_x, dst_y, ci) += val * x_prop * y_prop;
+          }
+
+          if (test_range (dst_x + 1, dst_y, 0, 0, w1, h1)) {
+            out_image->at(dst_x + 1, dst_y, ci) += val * (1 - x_prop) * y_prop;
+          }
+
+          if (test_range (dst_x, dst_y + 1, 0, 0, w1, h1)) {
+            out_image->at(dst_x, dst_y + 1, ci) += val * x_prop * (1 - y_prop);
+          }
+
+          if (test_range (dst_x + 1, dst_y + 1, 0, 0, w1, h1)) {
+            out_image->at(dst_x + 1, dst_y + 1, ci) += val * (1 - x_prop) * (1 - y_prop);
           }
         }
+      }
+    }
+  }
+  
+  //  border reinforcement
+  for (int yi = 0; yi < h1; ++yi) {
+    auto src_y = (yi < offset) ? offset
+      : ((h1 - offset - 1 < yi) ? (h1 - offset - 1)
+      : yi);
 
-        //  For this series of tests, we need to ensure that we only add
-        //  `value` to texels that actually exist in our dest image. Note that
-        //  this is basically just linear filtering routine with a fake border.
-        if (x_prop > 0.999 && y_prop > 0.999) {
-          if ((0 <= new_x) && (0 <= new_y)
-              && (new_width > new_x) && (new_height > new_y)) {
-            out_image->at(new_x, new_y, ci) += val;
-          }
-        } else if (x_prop > 0.999) {
-          if ((0 <= new_x) && (0 <= new_y)
-              && (new_width > new_x) && (new_height > new_y)) {
-            out_image->at(new_x, new_y, ci) += val * y_prop;
-          }
-          
-          if ((0 <= new_x) && (0 <= new_y)
-              && (new_width > new_x) && (new_height > new_y + 1)) {
-            out_image->at(new_x, new_y + 1, ci) += val * (1 - y_prop);
-          }
-        } else if (y_prop > 0.999) {
-          if ((0 <= new_x) && (0 <= new_y)
-              && (new_width > new_x) && (new_height > new_y)) {
-            out_image->at(new_x, new_y, ci) += val * x_prop;
-          }
+    for (int xi = 0; xi < w1; ++xi) {
+      auto src_x = (xi < offset) ? offset
+        : ((w1 - offset - 1 < xi) ? (w1 - offset - 1)
+        : xi);
 
-          if ((0 <= new_x) && (0 <= new_y)
-              && (new_width > new_x + 1) && (new_height > new_y)) {
-            out_image->at(new_x + 1, new_y, ci) += val * (1 - x_prop);
-          }
-        } else {
-          if ((0 <= new_x) && (0 <= new_y)
-              && (new_width > new_x) && (new_height > new_y)) {
-            out_image->at(new_x, new_y, ci) += val * x_prop * y_prop;
-          }
-
-          if ((0 <= new_x) && (0 <= new_y)
-              && (new_width > new_x + 1) && (new_height > new_y)) {
-            out_image->at(new_x + 1, new_y, ci) +=
-                val * (1 - x_prop) * y_prop;
-          }
-
-          if ((0 <= new_x) && (0 <= new_y)
-              && (new_width > new_x) && (new_height > new_y + 1)) {
-            out_image->at(new_x, new_y + 1, ci) +=
-                val * x_prop * (1 - y_prop);
-          }
-          
-          if ((0 <= new_x) && (0 <= new_y)
-              && (new_width > new_x + 1) && (new_height > new_y + 1)) {
-            out_image->at(new_x + 1, new_y + 1, ci) +=
-                val * (1 - x_prop) * (1 - y_prop);
-          }
-        }
+      for (int ci = 0; ci < image_i->channels(); ++ci) {
+        auto val = image_i->at(src_x, src_y, ci);
         
-        #undef HM_ASSERT
+        if ((yi < offset) || (yi >= h1_a + offset)
+          || (xi < offset) || (xi >= w1_a + offset)) {
+          out_image->at(xi, yi, ci) = val;
+        }
       }
     }
   }
@@ -433,7 +348,7 @@ void TexturePatch::rescale(double ratio) {
   validity_mask = mve::ByteImage::create(get_width(), get_height(), 1);
   blending_mask = mve::ByteImage::create(get_width(), get_height(), 1);
 
-  //  FIXME - bitweeder
+  //  SEEME - bitweeder
   //  Strictly speaking, these calls end up being redundant. Most likely, they
   //  should remain here and the other places we set them should have
   //  zero-fill as a precondition.
@@ -441,9 +356,11 @@ void TexturePatch::rescale(double ratio) {
   blending_mask->fill(0);
 
   if (texcoords.size() >= 3) {
+    //  SEEME - bitweeder
     //  We handle these as triples in case the relative positioning turns out
     //  to be important to avoid degeneration when applying scaling to the
-    //  triangle.
+    //  triangle. This is more likely to come into play if we start supporting
+    //  rotation during texture chart packing.
     for (std::size_t i = 0; i < texcoords.size(); i += 3) {
       auto& v1 = texcoords[i];
       auto& v2 = texcoords[i + 1];
@@ -457,7 +374,7 @@ void TexturePatch::rescale(double ratio) {
   
   std::vector<math::Vec3f> patch_adjust_values(
       get_faces().size() * 3, math::Vec3f(0.0f));
-
+  
   adjust_colors(patch_adjust_values);
 }
 
@@ -546,8 +463,27 @@ void TexturePatch::adjust_colors(
     int const max_x = static_cast<int>(std::ceil(aabb.max_x)) + texture_patch_border;
     int const max_y = static_cast<int>(std::ceil(aabb.max_y)) + texture_patch_border;
 
-    assert(0 <= min_x && max_x <= get_width());
-    assert(0 <= min_y && max_y <= get_height());
+    #define HM_ASSERT(test_) \
+      if (!(test_)) {\
+        std::cout << "failed: " << #test_ << std::endl; \
+        std::cout \
+        << "min: (" \
+        << min_x << ", " \
+        << min_y << "), " \
+        << "max: (" \
+        << max_x << ", " \
+        << max_y << "), " \
+        << "size: (" \
+        << get_width() << ", " \
+        << get_height() << ")" \
+        << std::endl; \
+        assert(test_); \
+      }
+
+    HM_ASSERT(0 <= min_x);
+    HM_ASSERT(0 <= min_y);
+    HM_ASSERT(max_x <= get_width());
+    HM_ASSERT(max_y <= get_height());
 
     for (int y = min_y; y < max_y; ++y) {
       for (int x = min_x; x < max_x; ++x) {
@@ -555,7 +491,8 @@ void TexturePatch::adjust_colors(
         bool inside = bcoords.minimum() >= 0.0f;
 
         if (inside) {
-          assert(x != 0 && y != 0);
+          HM_ASSERT(x != 0);
+          HM_ASSERT(y != 0);
 
           if (!only_regenerate_masks) {
             for (int c = 0; c < num_channels; ++c) {
@@ -602,6 +539,8 @@ void TexturePatch::adjust_colors(
           blending_mask->at(x, y, 0) = 64;        }
       }
     }
+    
+    #undef HM_ASSERT
   }
 
   if (!only_regenerate_masks) {

--- a/libs/tex/texture_patch.h
+++ b/libs/tex/texture_patch.h
@@ -68,11 +68,11 @@ public:
   TexturePatch::Ptr duplicate();
 
   void rescale(double ratio);
-  void regenerate_masks();
 
   /** Adjust the image colors and update validity mask. */
   void adjust_colors(
       std::vector<math::Vec3f> const& adjust_values,
+      bool only_regenerate_masks = false,
       int num_channels = 3);
 
   math::Vec3f get_pixel_value(math::Vec2f pixel) const;


### PR DESCRIPTION
- Pinkenstein is dead
- some additional distortions removed
- all local tests cleared
- code cleaned up

You’re being included as a reviewer for this PR for tracking purposes. I’m merging this into mvs-texturing `master` from now in order to generate a new DevImage: I need the commit hashes to match so we can take advantage of the effort. I anticipate no issues, but note that simply being in `maser` won’t impact Hive code without a corresponding merge to `master` over there changing the commit we’re pinned to. Once the image is built, I’ll be running end-to-end tests, but—once again— expect no issues since I’ve already successfully tested against tiled pipelines using both single model and combined mesh.