### PR TITLE
Added clamps to block scaling-related termination

### DIFF
--- a/libs/mvs_tex_wrapper/wrapper.cpp
+++ b/libs/mvs_tex_wrapper/wrapper.cpp
@@ -446,7 +446,7 @@ void textureMesh(
   //  do this--otherwise skip to cleanup and exit
   if (do_texture_atlas) {
     // Now loop, generating+saving subindexed meshes and atlas
-    #pragma omp parallel for schedule(dynamic)
+//    #pragma omp parallel for schedule(dynamic)
     for (std::size_t vi = 0; vi < sub_vert_masks.size(); ++vi) {
       std::cout << "\nFinalizing Sub-Model " << sub_names[vi] << " - " << vi + 1
                 << " of " << sub_vert_masks.size() << std::endl;
@@ -519,7 +519,7 @@ void textureMesh(
                 << texture_patches.size() << " patches." << std::endl;
 
       //  Generate texture atlases.
-      std::cout << "Generating texture atlases:" << std::endl;
+      std::cout << "\nGenerating texture atlases: " << std::flush;
       if (settings.scale_if_needed) {
         tex::generate_capped_texture_atlas(
           &sub_texture_patches,

--- a/libs/tex/generate_texture_atlases.cpp
+++ b/libs/tex/generate_texture_atlases.cpp
@@ -190,7 +190,7 @@ void generate_capped_texture_atlas(
     uint max_atlas_dim,
     const std::vector<math::Vec3f>& vertices,
     const std::vector<uint>& faces) {
-  std::cout << "generate_capped_texture_atlas beginning" <<std::endl;
+  std::cout << "generate_capped_texture_atlas beginning" << std::endl;
 
 //  std::cout << "max_atlas_dim: " << max_atlas_dim << std::endl;
 //  max_atlas_dim = 16 * 1024;
@@ -352,7 +352,7 @@ void generate_capped_texture_atlas(
     
     if ((scaling < 0.01) || (iterations >= 10)) {
       std::cout << "Unable to complete atlas page at all" << std::endl;
-      return;
+      break;
     }
   }
 }
@@ -363,7 +363,7 @@ void generate_texture_atlases(
     TextureAtlases* texture_atlases,
     const std::vector<math::Vec3f>& vertices,
     const std::vector<uint>& faces) {
-  std::cout << "generate_texture_atlases beginning" <<std::endl;
+  std::cout << "generate_texture_atlases beginning" << std::endl;
 
   auto texture_patches = prepare_patches(orig_texture_patches, settings);
   auto const total_num_patches = texture_patches.size();

--- a/libs/tex/texture_patch.cpp
+++ b/libs/tex/texture_patch.cpp
@@ -520,8 +520,8 @@ void TexturePatch::adjust_colors(
     
     min_x = std::max (0, min_x);
     min_y = std::max (0, min_y);
-    max_x = std::min (get_width(), min_x);
-    max_y = std::min (get_height(), min_y);
+    max_x = std::min (get_width(), max_x);
+    max_y = std::min (get_height(), max_y);
 
     for (int y = min_y; y < max_y; ++y) {
       for (int x = min_x; x < max_x; ++x) {

--- a/libs/tex/texture_patch.cpp
+++ b/libs/tex/texture_patch.cpp
@@ -138,10 +138,10 @@ TexturePatch::TexturePatch(
 */
 math::Vec2f scale_texcoord(
     math::Vec2f const& tc,
-    int old_width,
-    int old_height,
-    int new_width,
-    int new_height);
+    int old_width_i,
+    int old_height_i,
+    int new_width_i,
+    int new_height_i);
 math::Vec2f scale_texcoord(
     math::Vec2f const& tc,
     int old_width_i,
@@ -160,8 +160,42 @@ math::Vec2f scale_texcoord(
 
   auto x = (tc[0] - offset) * x_scale + offset;
   auto y = (tc[1] - offset) * y_scale + offset;
+  auto clamp = [](auto v, auto min_v, auto max_v) {
+    return (v < min_v) ? min_v : ((v > max_v) ? max_v : v);
+  };
 
-  nrv = {x, y};
+  auto adj_x = clamp(x, offset, new_width_i - offset);
+  auto adj_y = clamp(y, offset, new_height_i - offset);
+  
+  #define HM_ASSERT(test_) \
+    if (!(test_)) {\
+      std::cout << "clamped: " << #test_ << std::endl; \
+      std::cout \
+      << "old: (" \
+      << old_width_i << ", " \
+      << old_height_i << ")" \
+      << ", new: (" \
+      << new_width_i << ", " \
+      << new_height_i << ")" \
+      << ", offset: " << offset \
+      << ", tc: (" \
+      << tc[0] << ", " \
+      << tc[1] << ")" \
+      << ", calc: (" \
+      << x << ", " \
+      << y << ")" \
+      << ", adj: (" \
+      << adj_x << ", " \
+      << adj_y << ")" \
+      << std::endl; \
+    }
+  
+  HM_ASSERT(x == adj_x);
+  HM_ASSERT(y == adj_y);
+
+  nrv = {adj_x, adj_y};
+  
+  #undef HM_ASSERT
 
   return nrv;
 }
@@ -458,10 +492,10 @@ void TexturePatch::adjust_colors(
     }
 
     auto aabb = tri.get_aabb();
-    int const min_x = static_cast<int>(std::floor(aabb.min_x)) - texture_patch_border;
-    int const min_y = static_cast<int>(std::floor(aabb.min_y)) - texture_patch_border;
-    int const max_x = static_cast<int>(std::ceil(aabb.max_x)) + texture_patch_border;
-    int const max_y = static_cast<int>(std::ceil(aabb.max_y)) + texture_patch_border;
+    int min_x = static_cast<int>(std::floor(aabb.min_x)) - texture_patch_border;
+    int min_y = static_cast<int>(std::floor(aabb.min_y)) - texture_patch_border;
+    int max_x = static_cast<int>(std::ceil(aabb.max_x)) + texture_patch_border;
+    int max_y = static_cast<int>(std::ceil(aabb.max_y)) + texture_patch_border;
 
     #define HM_ASSERT(test_) \
       if (!(test_)) {\
@@ -477,13 +511,17 @@ void TexturePatch::adjust_colors(
         << get_width() << ", " \
         << get_height() << ")" \
         << std::endl; \
-        assert(test_); \
       }
 
     HM_ASSERT(0 <= min_x);
     HM_ASSERT(0 <= min_y);
     HM_ASSERT(max_x <= get_width());
     HM_ASSERT(max_y <= get_height());
+    
+    min_x = std::max (0, min_x);
+    min_y = std::max (0, min_y);
+    max_x = std::min (get_width(), min_x);
+    max_y = std::min (get_height(), min_y);
 
     for (int y = min_y; y < max_y; ++y) {
       for (int x = min_x; x < max_x; ++x) {
@@ -493,7 +531,7 @@ void TexturePatch::adjust_colors(
         if (inside) {
           HM_ASSERT(x != 0);
           HM_ASSERT(y != 0);
-
+          
           if (!only_regenerate_masks) {
             for (int c = 0; c < num_channels; ++c) {
               iadjust_values->at(x, y, c) = math::interpolate(


### PR DESCRIPTION
My suspicion is that the failures we’re seeing result from over-shrinking small triangles at the more extreme mipmap sizes. The current handling of degenerate triangles probably missed some situations where triangles could end up with negative area due to the way borders are handled. I can’t test this against the live data in equivalent-to-production scenarios at the moment since GRiD is still down, because of course it is.

I’m looking for additional potential failure points in the meantime.