### PR TITLE
Support tuning texture atlas scaling

### DIFF
--- a/libs/mvs_tex_wrapper/wrapper.cpp
+++ b/libs/mvs_tex_wrapper/wrapper.cpp
@@ -154,6 +154,11 @@ void textureMesh(
   settings.expose_blending_mask = texture_settings.do_expose_blending_mask;
   settings.expose_validity_mask = texture_settings.do_expose_validity_mask;
   settings.scale_if_needed = texture_settings.do_scale_if_needed;
+
+  settings.texture_scaling_adj = texture_settings.texture_scaling_adj;
+  settings.texture_scaling_backstop = texture_settings.texture_scaling_backstop;
+  settings.texture_scaling_min = texture_settings.texture_scaling_min;
+  settings.texture_scaling_max_iterations = texture_settings.texture_scaling_max_iterations;
   
   std::cout << "dilate_padding_pixels: " << settings.dilate_padding_pixels << std::endl;
   std::cout << "highlight_padding_pixels: " << settings.highlight_padding_pixels << std::endl;

--- a/libs/mvs_tex_wrapper/wrapper.h
+++ b/libs/mvs_tex_wrapper/wrapper.h
@@ -9,6 +9,39 @@
 namespace MvsTexturing {
 
 struct TextureSettings {
+  //  This is the scaling applied to our texture atlas candidate charts on
+  //  every iteration of the page-fitting algorithm. It should be conservative,
+  //  as the algorithm is already careful about page-fitting for reasonable
+  //  candidates (convergence within 2-3 iterations for 98%+ of candidates).
+  double texture_scaling_adj = 0.99;
+
+  //  This is the last ditch value attempted after the nth scaing iteration. We
+  //  are, at this point dealing with a pathological case, and so the goal is
+  //  to ensure that a representative atlas page is generated _at all_. As
+  //  such, any sufficiently small scaling will do, though we’d prefer
+  //  something that doesn’t result in a single color representng the whole
+  //  mesh tile. `0.666` was used successully with sub-million-point meshes of
+  //  consistent density.
+  double texture_scaling_backstop = 0.666;
+
+  //  This represents the smallest scaling we allow relative to the original
+  //  computed texture atlas chart sizes. Long before we get anywhere near
+  //  this, we’ll be experiencing a severe loss of quality relative to the
+  //  expected level of detail. If we would need to shrink the atlas more than
+  //  this, we assume the atlas is not worth preserving.
+  //
+  //  SEEME - bitweeder
+  //  Arguably, we could be much more liberal with what we accept here, as the
+  //  penalty for not having an atlas is severe (i.e., a missing mesh tile on
+  //  the map).
+  double texture_scaling_min = 0.01;
+
+  //  This is the largest number of iterations we perform in the texture atlas
+  //  scaling algorithm before giving up. This is intended as a defense against
+  //  pathological cases, as testing has shown we generally converge very, very
+  //  quickly.
+  std::size_t texture_scaling_max_iterations = 10;
+
   bool do_use_gmi_term = false;  // GMI vs area
   bool do_gauss_clamping = true; // one or other true, not both. Photometric consistency type
   bool do_gauss_damping = false;

--- a/libs/tex/generate_texture_atlases.cpp
+++ b/libs/tex/generate_texture_atlases.cpp
@@ -354,19 +354,17 @@ void generate_capped_texture_atlas(
       //  SEEME - bitweeder
       //  This is a simple heuristic to get “meaningful” scaling done every
       //  iteration. Adjust as needed.
-      if (scaling_adj > 0.99) {
-        scaling_adj = 0.99;
-      }
-
+      scaling_adj = std::min(scaling_adj, settings.texture_scaling_adj);
       scaling *= scaling_adj;
     }
     
-    if (iterations == 10) {
+    if (iterations == settings.texture_scaling_max_iterations) {
       std::cout << "Encountered a recalcitrant texture atlas! Taking extreme measures!" << std::endl;
-      scaling *= .666;
+      scaling *= settings.texture_scaling_backstop;
     }
 
-    if ((scaling < 0.01) || (iterations >= 11)) {
+    if ((scaling < settings.texture_scaling_min)
+        || (iterations > settings.texture_scaling_max_iterations)) {
       std::cout << "Unable to complete atlas page at all" << std::endl;
       break;
     }

--- a/libs/tex/settings.h
+++ b/libs/tex/settings.h
@@ -91,6 +91,11 @@ struct Settings {
   bool expose_blending_mask = false;
   bool expose_validity_mask = false;
   bool scale_if_needed = false;
+
+  double texture_scaling_adj = 0.99;
+  double texture_scaling_backstop = 0.666;
+  double texture_scaling_min = 0.01;
+  std::size_t texture_scaling_max_iterations = 10;
 };
 
 TEX_NAMESPACE_END


### PR DESCRIPTION
These changes make the texture atlas scaling algorithm client-tunable. Note that none of the existing values have changed, they’ve just all been turned into configurable settings variables; it is assumed tuning will happen exclusively on the Hive side, as needed.

This PR supports the changes to the backstop we’d discussed which will provide the balance of the solution to future incarnations of the vanishing mesh tile problem (at least until we replace the `mvs-texturing` texture atlas generation scheme altogether). Once we merge this, a new DepPackage will need to be generated and a corresponding change will need to be made to `mvs-texturing.sh` in the Hive source. Note that no other code changes are necessary to simply use this, as all settings have reasonable defaults. We can, of course, incorporate a change to the backstop value immediately on the Hive side, if so desired.