### PR TITLE
Move texture constants to a namespace

### DIFF
--- a/libs/tex/generate_texture_atlases.cpp
+++ b/libs/tex/generate_texture_atlases.cpp
@@ -24,18 +24,6 @@
 #include "texture_patch.h"
 #include "texturing.h"
 
-//  FIXME - bitweeder
-//  It’s unclear what the significance of these magic numbers is supposed to
-//  be, e.g., “maximum dimension size allowed for a POT texture, as imposed by
-//  the graphics API”. In context, the bounding rect of a given texture chart
-//  plus its padding is not allowed to exceed MAX_TEXTURE_SIZE in either the
-//  x or y dimension, but it’s unclear where this limitation comes from.
-//  PREF_TEXTURE_SIZE is even more mysterious.
-#define MAX_TEXTURE_SIZE (16 * 1024)
-#define MAX_SEGMENTATION_TEXTURE_SIZE (4 * 1024)
-#define PREF_TEXTURE_SIZE (16 * 1024)
-#define MIN_TEXTURE_SIZE (256)
-
 TEX_NAMESPACE_BEGIN
 
 /**

--- a/libs/tex/texturing.h
+++ b/libs/tex/texturing.h
@@ -39,6 +39,18 @@ using DataCosts = SparseTable<std::uint32_t, std::uint16_t, float>;
 using VertexProjectionInfos = std::vector<std::vector<VertexProjectionInfo>>;
 using FaceProjectionInfos = std::vector<std::vector<FaceProjectionInfo>>;
 
+//  FIXME - bitweeder
+//  It’s unclear what the significance of these magic numbers is supposed to
+//  be, e.g., “maximum dimension size allowed for a POT texture, as imposed by
+//  the graphics API”. In context, the bounding rect of a given texture chart
+//  plus its padding is not allowed to exceed MAX_TEXTURE_SIZE in either the
+//  x or y dimension, but it’s unclear where this limitation comes from.
+//  PREF_TEXTURE_SIZE is even more mysterious.
+constexpr int MAX_TEXTURE_SIZE = 16 * 1024;
+constexpr int MAX_SEGMENTATION_TEXTURE_SIZE = 4 * 1024;
+constexpr int PREF_TEXTURE_SIZE = 16 * 1024;
+constexpr int MIN_TEXTURE_SIZE = 256;
+
 /**
  * prepares the mesh for texturing
  *  -removes duplicated faces


### PR DESCRIPTION
Eliminated the old preprocessor macros and replaced them with proper constants defined in a common header.